### PR TITLE
FIXED #28: Search process should not work when the search field is empty

### DIFF
--- a/lib/ui/search_page.dart
+++ b/lib/ui/search_page.dart
@@ -10,15 +10,24 @@ import 'package:openlib/state/state.dart'
         typeValues,
         sortValues;
 
+import 'components/snack_bar_widget.dart';
+
 class SearchPage extends ConsumerWidget {
   const SearchPage({Key? key}) : super(key: key);
 
   void onSubmit(BuildContext context, WidgetRef ref) {
-    Navigator.push(context, MaterialPageRoute(builder: (BuildContext context) {
-      return ResultPage(
-        searchQuery: ref.read(searchQueryProvider),
-      );
-    }));
+    if(ref.read(searchQueryProvider).isNotEmpty) {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (BuildContext context) {
+        return ResultPage(
+          searchQuery: ref.read(searchQueryProvider),
+        );
+      }
+      ));
+    }
+    else{
+      showSnackBar(context: context, message: 'Search field is empty');
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+1
+version: 1.0.2+1
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
### **What does this PR do?**

This PR fixes the issue of the search being processed even after the search field is empty. In this updated code, a snack bar will be thrown indicating user that the "Search field is empty"  when the user taps the search icon even when the search field is empty.

Fixes #28 

### **Type of change**

- In the onSubmit function of the Search Page, an if-else statement is used to check if the search field is not empty then proceed else throw a snack bar.

### **Updated Output**


https://github.com/dstark5/Openlib/assets/84122396/f61c06cc-bbd0-4fe2-9844-232aa2688fad

