### PR TITLE
add file contexts (intent / MIME)

### DIFF
--- a/lib/ui/epub_viewer.dart
+++ b/lib/ui/epub_viewer.dart
@@ -33,7 +33,8 @@ Future<void> launchEpubViewer(
     String? epubConfig = await dataBase.getBookState(fileName);
 
     if (openWithExternalApp) {
-      await OpenFile.open(path, linuxByProcess: true);
+      await OpenFile.open(path,
+          linuxByProcess: true, type: "application/epub+zip");
     } else {
       try {
         VocsyEpub.setConfig(

--- a/lib/ui/pdf_viewer.dart
+++ b/lib/ui/pdf_viewer.dart
@@ -29,7 +29,7 @@ Future<void> launchPdfViewer(
   bool openWithExternalApp = ref.watch(openPdfWithExternalAppProvider);
   if (openWithExternalApp) {
     String path = await getFilePath(fileName);
-    await OpenFile.open(path, linuxByProcess: true);
+    await OpenFile.open(path, linuxByProcess: true, type: "application/pdf");
   } else {
     Navigator.push(context, MaterialPageRoute(builder: (BuildContext context) {
       return PdfView(


### PR DESCRIPTION
Added intents to enable proper android external reader selection, both for epub and pdf, as discussed in #72 and  #145  .

I tested it on my Android phone and confirmed it to work as expected, and also checked that it does not break anything for windows (cant open .epub files in windows with external reader, but that was the same before. Opening pdfs in external viewer works)

I would have assigned the issue to me, but I think I don't have the authorisation for that