### PR TITLE
Updated the base URL domain from .se to .li

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Openlib
 
-An Open source app to download and read books from shadow library ([Anna’s Archive](https://annas-archive.se/))
+An Open source app to download and read books from shadow library ([Anna’s Archive](https://annas-archive.li/))
 
 [![made-with-flutter](https://img.shields.io/badge/Made%20with-Flutter-4361ee.svg?style=for-the-badge)](https://flutter.dev/)
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-e63946.svg?style=for-the-badge)](https://opensource.org/licenses/)
@@ -43,9 +43,9 @@ An Open source app to download and read books from shadow library ([Anna’s Arc
 
 ## Description 📖
 
-Openlib Is An Open Source App To Download And Read Books From Shadow Library ([Anna’s Archive](https://annas-archive.se/)). The App Has Built In Reader to Read Books
+Openlib Is An Open Source App To Download And Read Books From Shadow Library ([Anna’s Archive](https://annas-archive.li/)). The App Has Built In Reader to Read Books
 
-As [Anna’s Archive](https://annas-archive.se/) Doesn't Have An API. The App Works By Sending Request To Anna’s Archive And Parses The Response To objects. The App Extracts The Mirrors From Response And Downloads The Book
+As [Anna’s Archive](https://annas-archive.li/) Doesn't Have An API. The App Works By Sending Request To Anna’s Archive And Parses The Response To objects. The App Extracts The Mirrors From Response And Downloads The Book
 
 ## Features ✨
 
@@ -111,7 +111,7 @@ Please report bugs via the [issue tracker](https://github.com/dstark5/Openlib/is
 
 If you like Openlib, you're welcome to send a donation.
 
-[Donate To Anna’s Archive.](https://annas-archive.se/donate?tier=1)
+[Donate To Anna’s Archive.](https://annas-archive.li/donate?tier=1)
 
 ## License 📜
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,5 +1,5 @@
 <p>
-<b><i>Openlib</i></b> is an open source app to download and read books from shadow library (<a href='https://annas-archive.se/' target='_blank' rel='nofollow noopener'>Anna’s Archive</a>). The App Has Built In Reader to Read Books.
+<b><i>Openlib</i></b> is an open source app to download and read books from shadow library (<a href='https://annas-archive.li/' target='_blank' rel='nofollow noopener'>Anna’s Archive</a>). The App Has Built In Reader to Read Books.
 </p>
 <p>
 As <i>Anna’s Archive</i> doesn't have an API, the app works by sending requests to <i>Anna’s Archive</i> and parses the response to objects. The app extracts the mirrors from the responses, downloads the book and stores it in the application's document directory.

--- a/lib/services/annas_archieve.dart
+++ b/lib/services/annas_archieve.dart
@@ -53,7 +53,7 @@ class BookInfoData extends BookData {
 // ====================================================================
 
 class AnnasArchieve {
-  static const String baseUrl = "https://annas-archive.se";
+  static const String baseUrl = "https://annas-archive.li";
 
   final Dio dio = Dio();
 

--- a/lib/services/download_file.dart
+++ b/lib/services/download_file.dart
@@ -24,7 +24,7 @@ List<String> _reorderMirrors(List<String> mirrors) {
     if (element.contains('ipfs') == true) {
       ipfsMirrors.add(element);
     } else {
-      if (element.startsWith('https://annas-archive.se') != true &&
+      if (element.startsWith('https://annas-archive.li') != true &&
           element.startsWith('https://1lib.sk') != true) {
         httpsMirrors.add(element);
       }


### PR DESCRIPTION
The OpenLib app cannot connect to anna's archive because it has an outdated URL in 'https://annas-archive.se'.

This PR updates all the annas-archive URLs found in the repo to 'https://annas-archive.li'. 